### PR TITLE
Smbpm File Deciphered

### DIFF
--- a/scripts/blueprint/blueprint.py
+++ b/scripts/blueprint/blueprint.py
@@ -181,6 +181,7 @@ def readMetaFile(fileName):
             4       wchar[N]        ship subfolder string given in modified UTF-8 encoding
             vary    int[3]          q vector, the location of the dock block
             vary    float[3]        a vector, ???
+            vary    short           block ID of the dock block
             
         tagStruct encodes variety of data types in a tree structure
         start       type


### PR DESCRIPTION
Most of the smbpm file format (blueprint meta file) is deciphered in this update

I was successfully able to parse a variety of smaller ship designs with the general readBlueprint function as well as a larger ship consist of ~90k blocks and data appears correct
