### PR TITLE
Fixed the parsing of the block bitfield

### DIFF
--- a/scripts/blueprint/blueprint.py
+++ b/scripts/blueprint/blueprint.py
@@ -262,7 +262,7 @@ def readMetaFile(fileName):
     
     start     type
         0       int             unknown int
-        4       byte            unknown byte
+        4       byte            unknown byte. Currently expecting a 0x03 here.
         5       int             number of dockEntry (docked ship/turrets)
         9       dockEntry[N]    data about each docked ship/turret
         vary    byte            unknown byte


### PR DESCRIPTION
Primarily I fixed an error that jjaquinta pointed out having to do with the bitfield used in the block data.

I also pulled out the entity parsing code from the meta file reader so it can be used to parse entity files in general.

Lastly added a check for the header byte in meta.smbpm file to be 0x3.  In the Isanth default blueprint this byte is a 0x1 and marked the end of the file.
